### PR TITLE
[Dev 90656] Added a new parameter raise_memcached_errors to add method

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -92,7 +92,7 @@ class PyLibMCCache(BaseMemcachedCache):
 
         return super(PyLibMCCache, self).get_backend_timeout(timeout)
 
-    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None, isSuppressMemcachedError=True):
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None, raise_memcached_errors=False):
         key = self.make_key(key, version=version)
         try:
             return self._cache.add(key, value,
@@ -104,9 +104,9 @@ class PyLibMCCache(BaseMemcachedCache):
             return False
         except MemcachedError as e:
             log.error('MemcachedError: %s', e, exc_info=True)
-            if isSuppressMemcachedError:
-                return False
-            raise
+            if raise_memcached_errors:
+                raise
+            return False
 
     def get(self, key, default=None, version=None):
         try:

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -92,7 +92,7 @@ class PyLibMCCache(BaseMemcachedCache):
 
         return super(PyLibMCCache, self).get_backend_timeout(timeout)
 
-    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None, isSuppressMemcachedError=True):
         key = self.make_key(key, version=version)
         try:
             return self._cache.add(key, value,
@@ -104,7 +104,9 @@ class PyLibMCCache(BaseMemcachedCache):
             return False
         except MemcachedError as e:
             log.error('MemcachedError: %s', e, exc_info=True)
-            return False
+            if isSuppressMemcachedError:
+                return False
+            raise
 
     def get(self, key, default=None, version=None):
         try:


### PR DESCRIPTION
Added a new parameter raise_memcached_errors to add method which defaults to False. 

Whenever memcached errors occur on the add method:
- If the raise_memcached_errors = True, memcached errors will be re-raised
- If the raise_memcached_errors = False, memcached errors will result in a return value of False
- If the raise_memcached_errors is not passed, memcached errors will result in False return value